### PR TITLE
Print root routes when running the start cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+__mocks__

--- a/commands/start.js
+++ b/commands/start.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const stubborn = require('stubborn-server');
 const out = require('simple-output');
+const globby = require('globby');
+const methods = require('methods');
 
 function startCmd(opts) {
 	const mockFolderName = opts.mockFolderName;
@@ -16,10 +20,35 @@ function startCmd(opts) {
 		});
 		out.success('Successfully launched snapstub server on: ' +
 			'http://localhost:' + port);
+		printRoutes(mockFolderName, port);
 	} catch (e) {
 		out.error('Failed to launch snapstub server');
 	}
 }
 
-module.exports = startCmd;
+function printRoutes(srcPath, port) {
+	globby('**/', { cwd: srcPath })
+		.then(paths => {
+			paths.forEach(pathName => {
+				if (methods.some(method => {
+					const fileLocation = path.join(srcPath, pathName, method);
+					return [
+						`${fileLocation}.js`,
+						`${fileLocation}.json`
+					].some(fileName => {
+						try {
+							fs.accessSync(fileName, fs.constants.R_OK);
+							return true;
+						} catch(err) {
+							return false;
+						}
+					});
+				})) {
+					out.info(`http://localhost:${port}/${pathName}`);
+				}
+			});
+		})
+		.catch(out.error);
+}
 
+module.exports = startCmd;

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "supertest": "^2.0.1"
   },
   "dependencies": {
+    "globby": "^6.1.0",
     "got": "^6.7.1",
     "jsonlint": "^1.6.2",
+    "methods": "^1.1.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "parse-headers": "^2.0.1",

--- a/test.js
+++ b/test.js
@@ -316,8 +316,11 @@ describe('snapstub', function () {
 			child.stderr.on('data', err => {
 				throw new Error(err.toString());
 			});
-			child.stdout.on('data', data => {
+			child.stdout.once('data', data => {
 				assert.equal(data.toString(), '✔  Successfully launched snapstub server on: http://localhost:8059\n');
+				child.stdout.once('data', d => {
+					assert.equal(d.toString(), 'ℹ  http://localhost:8059/data/\n');
+				});
 			});
 			setTimeout(() => {
 				child.kill();


### PR DESCRIPTION
Might be nice to print the root routes for the available directories so you can click and navigate.

Less typing!

![screen shot 2017-04-27 at 16 54 08](https://cloud.githubusercontent.com/assets/735303/25503986/2e83e2b0-2b6a-11e7-9b50-2f8ed0cb9405.png)

