### PR TITLE
Refactor print routes on start command

### DIFF
--- a/test.js
+++ b/test.js
@@ -318,7 +318,7 @@ describe('snapstub', function () {
 			});
 			function validateRouteMsg() {
 				child.stdout.once('data', d => {
-					assert.equal(d.toString(), 'ℹ  http://localhost:8059/data/\n');
+					assert.equal(d.toString(), 'ℹ  http://localhost:8059/data\n');
 				});
 			}
 			function validateSuccessMsg() {


### PR DESCRIPTION
I believe that by using `fs` plus the convoluted `if` I was checking twice for file existence.

I think _globby_ already does a good job matching the existing files. Also added a `Set` to print routes only once.