### PR TITLE
Add support to html and plain text endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Heavily inspired by [Jest Snapshot testing](https://facebook.github.io/jest/blog
 - [Advanced Usage](#advanced-usage)
 	- [Using different http methods](#using-different-http-methods)
 	- [Using custom headers to add a new route](#using-custom-headers-to-add-a-new-route)
+	- [Using html or plain text](#using-html-or-plain-text)
 	- [Sending data when adding a new route](#sending-data-when-adding-a-new-route)
 	- [Sending data read from a file](#sending-data-read-from-a-file)
 	- [Deterministic mocks using query-string or headers](#deterministic-mocks-using-query-string-or-headers)
@@ -91,6 +92,14 @@ You can set as many custom headers as you need:
 
 ```sh
 snapstub add http://example.com/api/login --header "X-User: foo" --header "X-Token: bar"
+```
+
+### Using html or plain text
+
+In order to save or add a html or plain text endpoint a `--nojson` flag must be specified in order to bypass json encode/decode:
+
+```sh
+snapstub add http://example.com/html --nojson
 ```
 
 ### Sending data when adding a new route

--- a/commands/help.js
+++ b/commands/help.js
@@ -17,6 +17,7 @@ Options:
   --method         Specifies http method to use along with add|save command
   --header         Adds a custom header to the request for add|save command
   --nohash         Don't generate hashed-filenames on add|save command
+  --nojson         Allow for saving html|text only on add|save command
   --hashAlgorithm  Algorithm to be used for deterministic responses
   --hashHeaders    Comma-separated list of header keys to be used on hash
   --hashCookies    Comma-separated list of cookies keys to be used on hash

--- a/commands/save.js
+++ b/commands/save.js
@@ -46,12 +46,15 @@ function saveCmd(opts) {
 			folderPath,
 			method.toLowerCase().trim() + hashSuffix + fileExt
 		);
+		const fileContent = nojson ?
+			`module.exports = (req, res) => { res.send('${stdin}'); };` :
+			jsonlint.formatter.formatJson(stdin);
 
 		// Creates mocks folder
 		mkdirp.sync(folderPath);
 
 		// Writes mock file
-		fs.writeFileSync(fileName, jsonlint.formatter.formatJson(stdin));
+		fs.writeFileSync(fileName, fileContent);
 		out.success(`Successfully added: ${fileName}`);
 	});
 }

--- a/test.js
+++ b/test.js
@@ -29,6 +29,9 @@ const putData = {
 };
 
 express()
+	.get('/html', (req, res) => {
+		res.send('<html><body><h1>Hello world</h1></body></html>');
+	})
 	.get('/data', (req, res) => {
 		res.json(Object.assign({},
 			data,
@@ -378,6 +381,14 @@ describe('snapstub cli', function () {
 					lorem: 'ipsum'
 				}
 			}))
+	}));
+
+	it('should be able to save and retrieve specific text based responses using --nojson option', runAndLoadMockTest({
+		cmd: './cli.js add http://localhost:9194/html --nojson',
+		supertests: () => request('http://localhost:8059')
+			.get('/html')
+			.expect('Content-Type', /text/)
+			.expect('<html><body><h1>Hello world</h1></body></html>')
 	}));
 
 	// ---


### PR DESCRIPTION
Using `--nojson` flag it's now possible to save arbitrary data on endpoints to be used later