### PR TITLE
fix glob to show all paths

### DIFF
--- a/commands/start.js
+++ b/commands/start.js
@@ -35,7 +35,7 @@ function startCmd(opts) {
 }
 
 function printRoutes(srcPath, port) {
-	const patterns = methods.map(m => `**/${m}.+(json|js|mjs|cjs)`);
+	const patterns = methods.map(m => `**/${m}*.+(json|js|mjs|cjs)`);
 
 	import('globby')
 		.then(({globby}) => globby(patterns, {cwd: srcPath}))


### PR DESCRIPTION
This pull request will make a simple change to the printRoutes() blog so that all routes show, even ones that only include hashed filenames